### PR TITLE
API docs for grpc client + remove session duplication

### DIFF
--- a/journal/src/test/scala/akka/persistence/spanner/internal/SpannerGrpcClientStubbedSpec.scala
+++ b/journal/src/test/scala/akka/persistence/spanner/internal/SpannerGrpcClientStubbedSpec.scala
@@ -4,5 +4,7 @@ import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class SpannerGrpcClientStubbedSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {
-  ""
+  "SpannerGrpcClient" should {
+    "have stubbed specs" in {}
+  }
 }


### PR DESCRIPTION
I looked into each of the method to see if there is any statuss we
should handle but it was only execute batch dml.

I left streaming sql as not to conflict, do you want to do with @johanandren ?
