### PR TITLE
Reuse session

### DIFF
--- a/journal/src/main/scala/akka/persistence/spanner/internal/SessionPool.scala
+++ b/journal/src/main/scala/akka/persistence/spanner/internal/SessionPool.scala
@@ -34,18 +34,21 @@ import scala.util.{Failure, Success}
 @InternalApi
 private[spanner] object SessionPool {
   sealed trait Command
-  final case class GetSession(replyTo: ActorRef[Response], id: UUID) extends Command
-  final case class ReleaseSession(id: UUID) extends Command
+  final case class GetSession(replyTo: ActorRef[Response], id: Long) extends Command
+  final case class ReleaseSession(id: Long) extends Command
 
   private final case class InitialSessions(sessions: List[Session]) extends Command
   private final case class RetrySessionCreation(in: FiniteDuration) extends Command
   private case object KeepAlive extends Command
 
   sealed trait Response {
-    val id: UUID
+    val id: Long
   }
-  final case class PooledSession(session: Session, id: UUID) extends Response
-  final case class PoolBusy(id: UUID) extends Response
+  final case class PooledSession(session: Session, id: Long) extends Response
+  final case class PoolBusy(id: Long) extends Response
+
+  private final case class ReAddAfterKeepAlive(session: Session) extends Command
+  private final case class ThrowAwayAfterKeepAliveFail(session: Session, cause: Throwable) extends Command
 
   private final case class AvailableSession(session: Session, lastUsed: Long)
 
@@ -121,7 +124,8 @@ private[spanner] final class SessionPool(
   private val log = ctx.log
   private var availableSessions: mutable.Queue[AvailableSession] =
     mutable.Queue(initialSessions.map(AvailableSession(_, System.currentTimeMillis())): _*)
-  private var inUseSessions = Map.empty[UUID, Session]
+  private var inUseSessions = Map.empty[Long, Session]
+  private var waitingForKeepAlive = Set.empty[Session]
 
   override def onMessage(msg: Command): Behavior[Command] = msg match {
     case gt @ GetSession(replyTo, id) =>
@@ -180,22 +184,31 @@ private[spanner] final class SessionPool(
           )
         }
         availableSessions = availableSessions.filterNot(s => toKeepAlive.contains(s.session))
+
         toKeepAlive.foreach { session =>
-          val id = UUID.randomUUID()
-          inUseSessions += (id -> session)
           ctx.pipeToSelf(client.executeSql(ExecuteSqlRequest(session.name, sql = "SELECT 1"))) {
-            case Success(_) =>
-              ReleaseSession(id)
-            case Failure(t) =>
-              log.warn(
-                s"Failed to keep session [${session.name}] alive, may be re-tried again before expires server side",
-                t
-              )
-              ReleaseSession(id)
+            case Success(_) => ReAddAfterKeepAlive(session)
+            case Failure(t) => ThrowAwayAfterKeepAliveFail(session, t)
           }
         }
       }
       this
+
+    case ReAddAfterKeepAlive(session) =>
+      availableSessions.enqueue(AvailableSession(session, System.currentTimeMillis()))
+      stash.unstash(this, 1, identity)
+      this
+
+    case ThrowAwayAfterKeepAliveFail(session, cause) =>
+      log.warn(
+        s"Failed to keep session [${session.name}] alive, may be re-tried again before expires server side",
+        cause
+      )
+      // FIXME is this really the right thing to do?
+      availableSessions.enqueue(AvailableSession(session, System.currentTimeMillis()))
+      stash.unstash(this, 1, identity)
+      this
+
     case other =>
       log.error("Unexpected message in active state {}", other)
       this

--- a/journal/src/test/scala/akka/persistence/spanner/internal/SessionPoolSpec.scala
+++ b/journal/src/test/scala/akka/persistence/spanner/internal/SessionPoolSpec.scala
@@ -24,8 +24,8 @@ class SessionPoolSpec extends SpannerSpec {
   class Setup {
     val pool: ActorRef[SessionPool.Command] = testkit.spawn(SessionPool(spannerClient, spannerSettings))
     val probe = testkit.createTestProbe[Response]()
-    val id1 = UUID.randomUUID()
-    val id2 = UUID.randomUUID()
+    val id1 = 1L
+    val id2 = 2L
   }
 
   "A session pool" should {
@@ -38,11 +38,10 @@ class SessionPoolSpec extends SpannerSpec {
 
     "should not return session until one available" in new Setup {
       // take all the sessions
-      val ids = (1 to settings.sessionPool.maxSize) map { _ =>
-        val id = UUID.randomUUID()
-        pool ! GetSession(probe.ref, id)
-        probe.expectMessageType[PooledSession].id shouldEqual id
-        id
+      val ids = (1 to settings.sessionPool.maxSize) map { n =>
+        pool ! GetSession(probe.ref, n)
+        probe.expectMessageType[PooledSession].id shouldEqual n
+        n
       }
 
       // should be stashed

--- a/journal/src/test/scala/akka/persistence/spanner/internal/SessionPoolStubbedSpec.scala
+++ b/journal/src/test/scala/akka/persistence/spanner/internal/SessionPoolStubbedSpec.scala
@@ -78,10 +78,10 @@ class SessionPoolStubbedSpec extends ScalaTestWithActorTestKit with Matchers wit
     val pool = testKit.spawn(SessionPool(stub, baseSettings))
     val sessions = List(Session("s1"), Session("s2"))
     val sessionProbe = testKit.createTestProbe[Response]()
-    val id1 = UUID.randomUUID()
-    val id2 = UUID.randomUUID()
-    val id3 = UUID.randomUUID()
-    val id4 = UUID.randomUUID()
+    val id1 = 1L
+    val id2 = 2L
+    val id3 = 3L
+    val id4 = 4L
 
     def expectBatchCreate() = {
       val response = probe.expectMessageType[BatchSessionCreateInvocation].response
@@ -185,7 +185,7 @@ class SessionPoolStubbedSpec extends ScalaTestWithActorTestKit with Matchers wit
       Set(keepAliveRequest1.input.session, keepAliveRequest2.input.session) shouldEqual sessions.map(_.name).toSet
     }
 
-    "sessions should not be available during keep alive" in new Setup {
+    "not provide a session that is waiting for keep alive to complete" in new Setup {
       expectBatchCreate()
       val keepAliveRequest1 = probe.expectMessageType[ExecuteSqlInvocation]
       val keepAliveRequest2 = probe.expectMessageType[ExecuteSqlInvocation]

--- a/journal/src/test/scala/akka/persistence/spanner/internal/StubbedSpannerGrpcClientSpec.scala
+++ b/journal/src/test/scala/akka/persistence/spanner/internal/StubbedSpannerGrpcClientSpec.scala
@@ -45,7 +45,7 @@ class StubbedSpannerGrpcClientSpec extends ScalaTestWithActorTestKit with Matche
       );
 
       // should not fail
-      client.write(Seq(Mutation())).futureValue
+      client.withSession(session => client.write(Seq(Mutation()))(session)).futureValue
       // should have retried
       retries.get should ===(0)
     }
@@ -88,11 +88,15 @@ class StubbedSpannerGrpcClientSpec extends ScalaTestWithActorTestKit with Matche
 
       // should not fail
       client
-        .executeBatchDml(
-          List(
-            ("PRETENDING TO BE A DML QUERY", Struct(), Map.empty),
-            ("PRETENDING TO BE ANOTHER DML QUERY", Struct(), Map.empty)
-          )
+        .withSession(
+          session =>
+            client
+              .executeBatchDml(
+                List(
+                  ("PRETENDING TO BE A DML QUERY", Struct(), Map.empty),
+                  ("PRETENDING TO BE ANOTHER DML QUERY", Struct(), Map.empty)
+                )
+              )(session)
         )
         .futureValue
       // should have retried


### PR DESCRIPTION
Re-use session for multi query operations instead of a return-renew for each, use long for session request id.

References #45
