### PR TITLE
Failing write causing actor to get stuck

### DIFF
--- a/journal/src/main/scala/akka/persistence/spanner/internal/SessionPool.scala
+++ b/journal/src/main/scala/akka/persistence/spanner/internal/SessionPool.scala
@@ -219,7 +219,7 @@ private[spanner] final class SessionPool(
           handOutSessionToQueuedRequest()
         } else {
           log.debugN(
-            "Session released with should re-create. Not returning this session to the pool [{}] (all [{}])",
+            "Session released with should re-create. Not returning this session to the pool [{}]",
             session.name
           )
           ctx.self ! CreateSingleSession

--- a/journal/src/main/scala/akka/persistence/spanner/internal/SessionPool.scala
+++ b/journal/src/main/scala/akka/persistence/spanner/internal/SessionPool.scala
@@ -218,7 +218,10 @@ private[spanner] final class SessionPool(
           availableSessions.enqueue(AvailableSession(session, System.currentTimeMillis()))
           handOutSessionToQueuedRequest()
         } else {
-          log.debug("Session released with should re-create. Not returning this session to the pool")
+          log.debugN(
+            "Session released with should re-create. Not returning this session to the pool [{}] (all [{}])",
+            session.name
+          )
           ctx.self ! CreateSingleSession
         }
       } else if (requestQueue.exists(_.id == id)) {
@@ -265,6 +268,7 @@ private[spanner] final class SessionPool(
       this
 
     case SessionKeepAliveSuccess(session) =>
+      log.trace("Session keep alive successful for [{}]", session.name)
       availableSessions.enqueue(AvailableSession(session, System.currentTimeMillis()))
       handOutSessionToQueuedRequest()
       this
@@ -296,7 +300,7 @@ private[spanner] final class SessionPool(
       this
 
     case SessionCreated(s) =>
-      log.debug("Replacement session created {}", s)
+      log.debug("Replacement session created [{}]", s)
       availableSessions.enqueue(AvailableSession(s, System.currentTimeMillis()))
       handOutSessionToQueuedRequest()
       this
@@ -308,7 +312,7 @@ private[spanner] final class SessionPool(
 
     case Stats =>
       statsLogger.debugN(
-        "Sessions inUse {}. Sessions available {}. Uss since last stats: {}. Ids {}. Request queue size {}",
+        "Sessions inUse {}. Sessions available {}. Uses since last stats: {}. Ids {}. Request queue size {}",
         inUseSessions.size,
         availableSessions.size,
         uses,

--- a/journal/src/main/scala/akka/persistence/spanner/internal/SpannerGrpcClient.scala
+++ b/journal/src/main/scala/akka/persistence/spanner/internal/SpannerGrpcClient.scala
@@ -52,7 +52,7 @@ private[spanner] object SpannerGrpcClient {
  */
 @InternalApi private[spanner] class SpannerGrpcClient(
     name: String,
-    client: SpannerClient,
+    val client: SpannerClient,
     system: ActorSystem[_],
     settings: SpannerSettings
 ) {

--- a/journal/src/test/scala/akka/persistence/spanner/SessionFaultToleranceSpec.scala
+++ b/journal/src/test/scala/akka/persistence/spanner/SessionFaultToleranceSpec.scala
@@ -1,0 +1,75 @@
+package akka.persistence.spanner
+
+import akka.Done
+import akka.persistence.spanner.TestActors.Persister
+import akka.persistence.spanner.internal.SpannerGrpcClientExtension
+import com.google.spanner.v1.DeleteSessionRequest
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+
+class SessionFaultToleranceSpec extends SpannerSpec {
+  override def customConfig: Config = ConfigFactory.parseString("""
+       # single session makes testing easier
+       akka.persistence.spanner.session-pool.max-size = 1
+      """)
+
+  "Failure handling when the session is invalidated" must {
+    "recover from a replay failure" in {
+      // create a persistent actor
+      val pid = nextPid()
+      val persister = testKit.spawn(Persister(pid))
+      val probe = testKit.createTestProbe[Done]()
+      persister ! Persister.PersistMe("e-1", probe.ref)
+      probe.expectMessage(Done)
+
+      // same client the journal will use
+      val spannerGrpcClient = SpannerGrpcClientExtension(testKit.system).clientFor("akka.persistence.spanner")
+
+      // sneakily delete the session id without letting the pool know, now it is returned to the pool
+      // but spanner has deleted it
+      spannerGrpcClient.withSession { session =>
+        testKit.system.log.debug("Sneakily deleting session {}", session.session.name)
+        spannerGrpcClient.client.deleteSession(DeleteSessionRequest.of(session.session.name))
+      }.futureValue
+
+      // replay fails
+      val persisterIncarnation2 = testKit.spawn(Persister(pid))
+      probe.expectTerminated(persisterIncarnation2)
+
+      // but session should be is invalidated, and a new one created so that the next operation succeeds
+      val persisterIncarnation3 = testKit.spawn(Persister(pid))
+      persisterIncarnation3 ! Persister.Ping(probe.ref)
+      probe.expectMessage(Done)
+    }
+
+    // covers bug #99
+    "recover from a write failure" in {
+      // create a persistent actor
+      val pid = nextPid()
+      val persister = testKit.spawn(Persister(pid))
+      val probe = testKit.createTestProbe[Done]()
+      persister ! Persister.PersistMe("e-1", probe.ref)
+      probe.expectMessage(Done)
+
+      // same client the journal will use
+      val spannerGrpcClient = SpannerGrpcClientExtension(testKit.system).clientFor("akka.persistence.spanner")
+
+      // sneakily delete the session id without letting the pool know, now it is returned to the pool
+      // but spanner has deleted it
+      spannerGrpcClient.withSession { session =>
+        testKit.system.log.debug("Sneakily deleting session {}", session.session.name)
+        spannerGrpcClient.client.deleteSession(DeleteSessionRequest.of(session.session.name))
+      }.futureValue
+
+      // trigger a write failure, stopping the actor
+      persister ! Persister.PersistMe("e-1", probe.ref)
+      probe.expectTerminated(persister)
+
+      // session should be invalidated, and a new one created so that the next operation
+      // (replay in this case) succeeds
+      val persisterIncarnation2 = testKit.spawn(Persister(pid))
+      persisterIncarnation2 ! Persister.Ping(probe.ref)
+      probe.expectMessage(Done)
+    }
+  }
+}

--- a/journal/src/test/scala/akka/persistence/spanner/SpannerSpec.scala
+++ b/journal/src/test/scala/akka/persistence/spanner/SpannerSpec.scala
@@ -141,7 +141,7 @@ trait SpannerLifecycle
   private val log = LoggerFactory.getLogger(classOf[SpannerLifecycle])
 
   private val pidCounter = new AtomicLong(0)
-  def nextPid = s"p-${pidCounter.incrementAndGet()}"
+  def nextPid() = s"p-${pidCounter.incrementAndGet()}"
 
   private val tagCounter = new AtomicLong(0)
   def nextTag = s"tag-${tagCounter.incrementAndGet()}"

--- a/journal/src/test/scala/akka/persistence/spanner/TestActors.scala
+++ b/journal/src/test/scala/akka/persistence/spanner/TestActors.scala
@@ -6,6 +6,7 @@ package akka.persistence.spanner
 
 import akka.Done
 import akka.actor.typed.{ActorRef, Behavior}
+import akka.persistence.spanner.TestActors.Tagger.Command
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.scaladsl.{Effect, EventSourcedBehavior}
 
@@ -31,11 +32,23 @@ object TestActors {
   }
 
   object Persister {
-    case class PersistMe(payload: Any, replyTo: ActorRef[Done])
+    sealed trait Command
+    case class PersistMe(payload: Any, replyTo: ActorRef[Done]) extends Command
+    case class Ping(replyTo: ActorRef[Done]) extends Command
 
-    def apply(pid: String): Behavior[PersistMe] =
-      EventSourcedBehavior[PersistMe, Any, String](persistenceId = PersistenceId.ofUniqueId(pid), "", (_, command) => {
-        Effect.persist(command.payload).thenRun(_ => command.replyTo ! Done)
-      }, (_, _) => "")
+    def apply(pid: String): Behavior[Command] =
+      EventSourcedBehavior[Command, Any, String](
+        persistenceId = PersistenceId.ofUniqueId(pid),
+        "", { (_, command) =>
+          command match {
+            case command: PersistMe =>
+              Effect.persist(command.payload).thenRun(_ => command.replyTo ! Done)
+            case Ping(replyTo) =>
+              replyTo ! Done
+              Effect.none
+          }
+        },
+        (_, _) => ""
+      )
   }
 }


### PR DESCRIPTION
References #99

Turns out there was nothing specifically related to session invalidation, but rather that we forgot to clean out the write in progress map on write completion. This meant that a Future result of a failed write (say with the deleted session exception) would stay around forever, even though the error only happened once, and be returned from `asyncReadHighestSequenceNr` on every try to replay after that. 🤦 