### PR TITLE
Added object changes support

### DIFF
--- a/journal/src/main/scala/akka/persistence/spanner/SpannerObjectStore.scala
+++ b/journal/src/main/scala/akka/persistence/spanner/SpannerObjectStore.scala
@@ -38,10 +38,42 @@ class SpannerObjectStore(interactions: SpannerObjectInteractions) {
 
   def deleteObject(persistenceId: PersistenceId): Future[Unit] = interactions.deleteObject(persistenceId)
 
+  /**
+   * Get a source of the most recent changes made to objects of the given entity type since the passed in offset.
+   *
+   * Note that this only returns the most recent change to each object, if an object has been updated multiple times
+   * since the offset, only the most recent of those changes will be part of the stream.
+   *
+   * This will return changes that occurred up to when the `Source` returned by this call is materialized. Changes to
+   * objects made since materialization are not guaranteed to be included in the results.
+   *
+   * @param entityType The type of entity to get changes for.
+   * @param offset The offset to get changes since. Must either be [[akka.persistence.query.NoOffset]] to get
+   *               changes since the beginning of time, or an offset that has been previously returned by this query.
+   *               Any other offsets are invalid.
+   * @return A source of change events.
+   */
   @ApiMayChange
   def currentChanges(entityType: String, offset: Offset): Source[Change, NotUsed] =
     interactions.currentChanges(entityType, offset)
 
+  /**
+   * Get a source of the most recent changes made to objects of the given entity type since the passed in offset.
+   *
+   * The returned source will never terminate, it effectively watches for changes to the objects and emits changes as
+   * they happen.
+   *
+   * Not all changes that occur are guaranteed to be emitted, this call only guarantees that eventually, the most
+   * recent change for each object since the offset will be emitted. In particular, multiple updates to a given object
+   * in quick succession are likely to be skipped, with only the last update resulting in a change event from this
+   * source.
+   *
+   * @param entityType The type of entity to get changes for.
+   * @param offset The offset to get changes since. Must either be [[akka.persistence.query.NoOffset]] to get
+   *               changes since the beginning of time, or an offset that has been previously returned by this query.
+   *               Any other offsets are invalid.
+   * @return A source of change events.
+   */
   @ApiMayChange
   def changes(entityType: String, offset: Offset): Source[Change, NotUsed] =
     interactions.changes(entityType, offset)

--- a/journal/src/main/scala/akka/persistence/spanner/internal/SpannerJournalInteractions.scala
+++ b/journal/src/main/scala/akka/persistence/spanner/internal/SpannerJournalInteractions.scala
@@ -81,8 +81,6 @@ private[spanner] object SpannerJournalInteractions {
         .toFormatter
         .withZone(ZoneOffset.UTC)
 
-      val NoOffset = SpannerUtils.unixTimestampMillisToSpanner(0L)
-
       val ReplayTypes = Map(
         "persistence_id" -> Type(TypeCode.STRING),
         "from_sequence_nr" -> Type(TypeCode.INT64),

--- a/journal/src/main/scala/akka/persistence/spanner/internal/SpannerUtils.scala
+++ b/journal/src/main/scala/akka/persistence/spanner/internal/SpannerUtils.scala
@@ -7,6 +7,9 @@ package akka.persistence.spanner.internal
 import java.time.Instant
 
 import akka.annotation.InternalApi
+import akka.persistence.query.{NoOffset, Offset}
+import akka.persistence.spanner.SpannerOffset
+import akka.persistence.spanner.internal.SpannerJournalInteractions.Schema
 import com.google.protobuf.struct.Value.Kind.NullValue
 
 /**
@@ -22,4 +25,13 @@ private[spanner] object SpannerUtils {
 
   val nullValue: NullValue =
     com.google.protobuf.struct.Value.Kind.NullValue(com.google.protobuf.struct.NullValue.NULL_VALUE)
+
+  val SpannerNoOffset = SpannerUtils.unixTimestampMillisToSpanner(0L)
+
+  def toSpannerOffset(offset: Offset) = offset match {
+    case NoOffset => SpannerOffset(SpannerNoOffset, Map.empty)
+    case so: SpannerOffset => so
+    case _ =>
+      throw new IllegalArgumentException(s"Spanner does not support offset type: " + offset.getClass)
+  }
 }

--- a/journal/src/main/scala/akka/persistence/spanner/internal/SpannerUtils.scala
+++ b/journal/src/main/scala/akka/persistence/spanner/internal/SpannerUtils.scala
@@ -32,6 +32,6 @@ private[spanner] object SpannerUtils {
     case NoOffset => SpannerOffset(SpannerNoOffset, Map.empty)
     case so: SpannerOffset => so
     case _ =>
-      throw new IllegalArgumentException(s"Spanner does not support offset type: " + offset.getClass)
+      throw new IllegalArgumentException(s"Spanner does not support offset type: ${offset.getClass}")
   }
 }

--- a/journal/src/test/scala/akka/persistence/spanner/SpannerObjectStoreSpec.scala
+++ b/journal/src/test/scala/akka/persistence/spanner/SpannerObjectStoreSpec.scala
@@ -1,12 +1,16 @@
 /*
- * Copyright (C) 2020 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.spanner
 
-import akka.persistence.spanner.SpannerObjectStore.Result
+import akka.persistence.query.NoOffset
+import akka.persistence.spanner.SpannerObjectStore.{Change, Result}
 import akka.persistence.typed.PersistenceId
+import akka.stream.scaladsl.Sink
+import akka.stream.testkit.scaladsl.TestSink
 import akka.util.ByteString
+import scala.concurrent.duration._
 
 class SpannerObjectStoreSpec extends SpannerSpec("SpannerObjectStoreSpec") {
   override def withObjectStore: Boolean = true
@@ -89,6 +93,65 @@ class SpannerObjectStoreSpec extends SpannerSpec("SpannerObjectStoreSpec") {
       spannerInteractions.getObject(persistenceId).futureValue should be(Some(Result(value, serId, serManifest, 0L)))
       spannerInteractions.deleteObject(persistenceId).futureValue
       spannerInteractions.getObject(persistenceId).futureValue should be(None)
+    }
+    "support querying for current changes" in {
+      val entityType = "current-changes"
+      val persistenceId1 = PersistenceId(entityType, "id-1")
+      val value1 = ByteString("Genuinely Collaborative")
+      spannerInteractions.upsertObject(entityType, persistenceId1, serId, serManifest, value1, 0L).futureValue
+      val persistenceId2 = PersistenceId(entityType, "id-2")
+      val value2 = ByteString("Open to Feedback")
+      spannerInteractions.upsertObject(entityType, persistenceId2, serId, serManifest, value2, 0L).futureValue
+
+      val changes1 = spannerInteractions.currentChanges(entityType, NoOffset).runWith(Sink.seq).futureValue
+      changes1 should have size (2)
+      val change1 = changes1.head
+      change1 should be(Change(persistenceId1.id, value1, serId, serManifest, 0L, change1.offset))
+      val change2 = changes1(1)
+      val expectedChange2 = Change(persistenceId2.id, value2, serId, serManifest, 0L, change2.offset)
+      change2 should be(expectedChange2)
+
+      val changes2 = spannerInteractions.currentChanges(entityType, change1.offset).runWith(Sink.seq).futureValue
+      changes2 should have size 1
+      changes2.head should be(expectedChange2)
+
+      val value3 = ByteString("Genuine and Sincere in all Communications")
+      spannerInteractions.upsertObject(entityType, persistenceId1, serId, serManifest, value3, 1L).futureValue
+
+      val changes3 = spannerInteractions.currentChanges(entityType, change2.offset).runWith(Sink.seq).futureValue
+      changes3 should have size 1
+      changes3.head should be(Change(persistenceId1.id, value3, serId, serManifest, 1L, changes3.head.offset))
+    }
+    "support continuous changes query" in {
+      val entityType = "continuous-changes"
+      val persistenceId1 = PersistenceId(entityType, "id-1")
+      val value1 = ByteString("Genuinely Collaborative")
+      spannerInteractions.upsertObject(entityType, persistenceId1, serId, serManifest, value1, 0L).futureValue
+      val persistenceId2 = PersistenceId(entityType, "id-2")
+      val value2 = ByteString("Open to Feedback")
+      spannerInteractions.upsertObject(entityType, persistenceId2, serId, serManifest, value2, 0L).futureValue
+
+      val probe = spannerInteractions.changes(entityType, NoOffset).runWith(TestSink.probe[Change])
+      probe.request(100)
+
+      val change1 = probe.expectNext()
+      change1 should be(Change(persistenceId1.id, value1, serId, serManifest, 0L, change1.offset))
+      val change2 = probe.expectNext()
+      change2 should be(Change(persistenceId2.id, value2, serId, serManifest, 0L, change2.offset))
+      probe.expectNoMessage(1.second)
+
+      val persistenceId3 = PersistenceId(entityType, "id-3")
+      val value3 = ByteString("Genuine and Sincere in all Communications")
+      spannerInteractions.upsertObject(entityType, persistenceId3, serId, serManifest, value3, 0L)
+      val change3 = probe.expectNext()
+      change3 should be(Change(persistenceId3.id, value3, serId, serManifest, 0L, change3.offset))
+
+      val value4 = ByteString("Always prefer Hacks over Well Engineered Solutions")
+      spannerInteractions.upsertObject(entityType, persistenceId1, serId, serManifest, value4, 1L)
+      val change4 = probe.expectNext()
+      change4 should be(Change(persistenceId1.id, value4, serId, serManifest, 1L, change4.offset))
+
+      probe.cancel()
     }
   }
 }

--- a/journal/src/test/scala/akka/persistence/spanner/SpannerSpec.scala
+++ b/journal/src/test/scala/akka/persistence/spanner/SpannerSpec.scala
@@ -214,7 +214,8 @@ trait SpannerLifecycle
          SpannerSnapshotInteractions.Schema.Snapshots.snapshotTable(spannerSettings) :: Nil
        else Nil) ++
       (if (withObjectStore)
-         SpannerObjectInteractions.Schema.Objects.objectTable(spannerSettings) :: Nil
+         SpannerObjectInteractions.Schema.Objects.objectTable(spannerSettings) ::
+         SpannerObjectInteractions.Schema.Objects.objectsByTypeOffsetIndex(spannerSettings) :: Nil
        else Nil)
     dbSchemas.foreach(log.debug(_))
 


### PR DESCRIPTION
This adds changes and currentChanges queries to the object store.

This change doesn't change any existing storage structure or format, except that it does add an index - however, given that `akka-persistence-spanner` doesn't actually create any tables/indexes for you, that's up to consumers of the library, the creation of that index is opt-in. The index does create a hotspot on inserting/updating objects for the same entity type.