### PR TITLE
Allow messages to actually be the max size for spanner

### DIFF
--- a/journal/src/main/scala/akka/persistence/spanner/SpannerObjectStore.scala
+++ b/journal/src/main/scala/akka/persistence/spanner/SpannerObjectStore.scala
@@ -87,6 +87,7 @@ class SpannerObjectStore(interactions: SpannerObjectInteractions) {
  *
  * INTERNAL API
  */
+@InternalStableApi
 object SpannerObjectStore {
   case class Result(byteString: ByteString, serId: Long, serManifest: String, seqNr: Long)
   case class Change(

--- a/journal/src/main/scala/akka/persistence/spanner/SpannerSettings.scala
+++ b/journal/src/main/scala/akka/persistence/spanner/SpannerSettings.scala
@@ -4,18 +4,18 @@
 
 package akka.persistence.spanner
 
-import akka.annotation.InternalApi
+import akka.annotation.InternalStableApi
 import akka.persistence.spanner.SpannerSettings.SessionPoolSettings
-import com.typesafe.config.Config
 import akka.util.JavaDurationConverters._
+import com.typesafe.config.Config
 
 import scala.concurrent.duration.FiniteDuration
 
 /**
  * INTERNAL API
  */
-@InternalApi
-private[spanner] object SpannerSettings {
+@InternalStableApi
+object SpannerSettings {
   final class SessionPoolSettings(config: Config) {
     val maxSize = config.getInt("max-size")
     // Spanner only supports 100 sessions per gRPC channel. We'd need multiple channels to support
@@ -37,15 +37,19 @@ private[spanner] object SpannerSettings {
   }
 }
 
-private[spanner] final class QuerySettings(config: Config) {
+/**
+ * INTERNAL API
+ */
+@InternalStableApi
+final class QuerySettings(config: Config) {
   val refreshInterval: FiniteDuration = config.getDuration("refresh-interval").asScala
 }
 
 /**
  * INTERNAL API
  */
-@InternalApi
-private[spanner] final class SpannerSettings(config: Config) {
+@InternalStableApi
+final class SpannerSettings(config: Config) {
   val project = config.getString("project")
   val instance = config.getString("instance")
   val database = config.getString("database")

--- a/journal/src/main/scala/akka/persistence/spanner/internal/SpannerGrpcClient.scala
+++ b/journal/src/main/scala/akka/persistence/spanner/internal/SpannerGrpcClient.scala
@@ -53,7 +53,7 @@ object SpannerGrpcClient {
  * INTERNAL API
  */
 @InternalStableApi
-final class SpannerGrpcClient(
+class SpannerGrpcClient(
     name: String,
     val client: SpannerClient,
     system: ActorSystem[_],

--- a/journal/src/main/scala/akka/persistence/spanner/internal/SpannerGrpcClient.scala
+++ b/journal/src/main/scala/akka/persistence/spanner/internal/SpannerGrpcClient.scala
@@ -5,11 +5,11 @@
 package akka.persistence.spanner.internal
 
 import java.util.concurrent.atomic.AtomicLong
-
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.actor.typed.scaladsl.{Behaviors, LoggerOps}
 import akka.actor.typed.{ActorRef, ActorSystem, SupervisorStrategy}
 import akka.annotation.InternalApi
+import akka.annotation.InternalStableApi
 import akka.dispatch.ExecutionContexts
 import akka.persistence.spanner.SpannerSettings
 import akka.persistence.spanner.internal.SessionPool._
@@ -31,8 +31,8 @@ import scala.util.{Failure, Success}
 /**
  * INTERNAL API
  */
-@InternalApi
-private[spanner] object SpannerGrpcClient {
+@InternalStableApi
+object SpannerGrpcClient {
   final class TransactionFailed(code: Int, message: String, details: Any)
       extends RuntimeException(s"Code $code. Message: $message. Params: $details")
 
@@ -49,8 +49,11 @@ private[spanner] object SpannerGrpcClient {
 
 /**
  * A thin wrapper around the gRPC client to expose only what the plugin needs.
+ *
+ * INTERNAL API
  */
-@InternalApi private[spanner] class SpannerGrpcClient(
+@InternalStableApi
+final class SpannerGrpcClient(
     name: String,
     val client: SpannerClient,
     system: ActorSystem[_],

--- a/journal/src/main/scala/akka/persistence/spanner/internal/SpannerGrpcClientExtension.scala
+++ b/journal/src/main/scala/akka/persistence/spanner/internal/SpannerGrpcClientExtension.scala
@@ -5,12 +5,12 @@
 package akka.persistence.spanner.internal
 
 import java.util.concurrent.ConcurrentHashMap
-
 import akka.Done
 import akka.actor.CoordinatedShutdown
 import akka.actor.typed.scaladsl.adapter._
 import akka.actor.typed.{ActorSystem, Extension, ExtensionId}
 import akka.annotation.InternalApi
+import akka.annotation.InternalStableApi
 import akka.grpc.GrpcClientSettings
 import akka.persistence.spanner.SpannerSettings
 import akka.util.ccompat.JavaConverters._
@@ -20,16 +20,22 @@ import io.grpc.auth.MoreCallCredentials
 
 import scala.concurrent.{ExecutionContext, Future}
 
-private[spanner] object SpannerGrpcClientExtension extends ExtensionId[SpannerGrpcClientExtension] {
+/**
+ * INTERNAL API
+ */
+@InternalStableApi
+object SpannerGrpcClientExtension extends ExtensionId[SpannerGrpcClientExtension] {
   override def createExtension(system: ActorSystem[_]): SpannerGrpcClientExtension =
     new SpannerGrpcClientExtension(system)
 }
 
 /**
  * Share client between parts of the plugin
+ *
+ * INTERNAL API
  */
-@InternalApi
-private[spanner] class SpannerGrpcClientExtension(system: ActorSystem[_]) extends Extension {
+@InternalStableApi
+final class SpannerGrpcClientExtension(system: ActorSystem[_]) extends Extension {
   private val sessions = new ConcurrentHashMap[String, SpannerGrpcClient]
   private implicit val classic = system.toClassic
   private implicit val ec: ExecutionContext = system.executionContext

--- a/journal/src/test/scala/akka/persistence/spanner/SpannerClientSpec.scala
+++ b/journal/src/test/scala/akka/persistence/spanner/SpannerClientSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.persistence.spanner
+
+import akka.persistence.spanner.internal.SpannerGrpcClientExtension
+import akka.persistence.spanner.internal.SpannerObjectInteractions
+import akka.persistence.typed.PersistenceId
+import akka.util.ByteString
+
+class SpannerClientSpec extends SpannerSpec {
+  override def withObjectStore: Boolean = true
+
+  "The spanner client" must {
+    "insert and read large chunks of data" in {
+      val grpcClient = SpannerGrpcClientExtension(testKit.system).clientFor("akka.persistence.spanner")
+      val objectInteractions = new SpannerObjectInteractions(grpcClient, spannerSettings)
+
+      val pid = PersistenceId("size", "1")
+      objectInteractions
+        .upsertObject(
+          "entity-1",
+          pid,
+          666L,
+          "nah",
+          // 10mb, spanner request limit
+          ByteString.fromArrayUnsafe(Array.tabulate[Byte](10485760)(_ => 1.toByte)),
+          1L
+        )
+        .futureValue
+
+      objectInteractions.getObject(pid).futureValue
+    }
+  }
+}

--- a/journal/src/test/scala/akka/persistence/spanner/SpannerClientSpec.scala
+++ b/journal/src/test/scala/akka/persistence/spanner/SpannerClientSpec.scala
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.persistence.spanner
 
 import akka.persistence.spanner.internal.SpannerGrpcClientExtension

--- a/journal/src/test/scala/akka/persistence/spanner/SpannerClientSpec.scala
+++ b/journal/src/test/scala/akka/persistence/spanner/SpannerClientSpec.scala
@@ -24,7 +24,7 @@ class SpannerClientSpec extends SpannerSpec {
           666L,
           "nah",
           // 10mb, spanner request limit
-          ByteString.fromArrayUnsafe(Array.tabulate[Byte](10485760)(_ => 1.toByte)),
+          ByteString.fromArrayUnsafe(Array.tabulate[Byte](10485760)(_.toByte)),
           1L
         )
         .futureValue


### PR DESCRIPTION
Underlying Akka gRPC Netty client limits to 4mb by default, with this PR we can reach 10mb which is the spanner limit
