### PR TITLE
Slice instead of tags

### DIFF
--- a/journal/src/main/scala/akka/persistence/spanner/SpannerSettings.scala
+++ b/journal/src/main/scala/akka/persistence/spanner/SpannerSettings.scala
@@ -75,5 +75,8 @@ final class SpannerSettings(config: Config) {
   val sessionPool = new SessionPoolSettings(config.getConfig("session-pool"))
   val sessionAcquisitionTimeout = config.getDuration("session-acquisition-timeout").asScala
 
+  // FIXME config
+  val maxNumberOfSlices = 128
+
   val querySettings = new QuerySettings(config.getConfig("query"))
 }

--- a/journal/src/main/scala/akka/persistence/spanner/internal/SliceUtils.scala
+++ b/journal/src/main/scala/akka/persistence/spanner/internal/SliceUtils.scala
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.persistence.spanner.internal
+
+import akka.annotation.InternalApi
+import akka.persistence.typed.PersistenceId
+import scala.collection.immutable
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[spanner] object SliceUtils {
+  def sliceForPersistenceId(persistenceId: String, maxNumberOfSlices: Int): Int =
+    math.abs(persistenceId.hashCode % maxNumberOfSlices)
+
+  def extractEntityTypeHintFromPersistenceId(persistenceId: String): String = {
+    val i = persistenceId.indexOf(PersistenceId.DefaultSeparator) // TODO configurable separator
+    if (i == -1) ""
+    else persistenceId.substring(0, i)
+  }
+
+  def sliceRanges(numberOfRanges: Int, maxNumberOfSlices: Int): immutable.Seq[Range] = {
+    val rangeSize = maxNumberOfSlices / numberOfRanges
+    require(
+      numberOfRanges * rangeSize == maxNumberOfSlices,
+      s"numberOfRanges [$numberOfRanges] must be a whole number divisor of maxNumberOfSlices [$maxNumberOfSlices]."
+    )
+    (0 until numberOfRanges).map { i =>
+      (i * rangeSize until i * rangeSize + rangeSize)
+    }.toVector
+  }
+}

--- a/journal/src/test/scala/akka/persistence/spanner/EventsBySliceSpec.scala
+++ b/journal/src/test/scala/akka/persistence/spanner/EventsBySliceSpec.scala
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.spanner
+
+import scala.concurrent.duration._
+
+import akka.persistence.query.EventEnvelope
+import akka.persistence.query.NoOffset
+import akka.persistence.query.Offset
+import akka.persistence.query.PersistenceQuery
+import akka.persistence.spanner.EventsByTagSpec.Current
+import akka.persistence.spanner.EventsByTagSpec.Live
+import akka.persistence.spanner.EventsByTagSpec.QueryType
+import akka.persistence.spanner.TestActors.Persister.PersistMe
+import akka.persistence.spanner.scaladsl.SpannerReadJournal
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import akka.stream.testkit.TestSubscriber
+import akka.stream.testkit.scaladsl.TestSink
+import akka.Done
+import akka.NotUsed
+import akka.persistence.spanner.internal.SliceUtils
+
+object EventsBySliceSpec {
+  sealed trait QueryType
+  case object Live extends QueryType
+  case object Current extends QueryType
+}
+
+class EventsBySliceSpec extends SpannerSpec {
+  import SliceUtils._
+  import spannerSettings.maxNumberOfSlices
+
+  val query = PersistenceQuery(testKit.system).readJournalFor[SpannerReadJournal](SpannerReadJournal.Identifier)
+
+  private class Setup {
+    val entityTypeHint = nextEntityTypeHint
+    val persistenceId = nextPid(entityTypeHint)
+    val persister = testKit.spawn(TestActors.Persister(persistenceId))
+    val probe = testKit.createTestProbe[Done]
+    val sinkProbe = TestSink.probe[EventEnvelope]
+  }
+
+  List[QueryType](Current).foreach { queryType =>
+    def doQuery(entityTypeHint: String, minSlice: Int, maxSlice: Int, offset: Offset): Source[EventEnvelope, NotUsed] =
+      queryType match {
+        case Live =>
+          query.eventsBySlices(entityTypeHint, minSlice, maxSlice, offset)
+        case Current =>
+          query.currentEventsBySlices(entityTypeHint, minSlice, maxSlice, offset)
+      }
+
+    def assertFinished(probe: TestSubscriber.Probe[EventEnvelope]): Unit =
+      queryType match {
+        case Live =>
+          probe.expectNoMessage()
+          probe.cancel()
+        case Current =>
+          probe.expectComplete()
+      }
+
+    s"$queryType EventsBySlices" should {
+      "return all events for NoOffset" in new Setup {
+        for (i <- 1 to 20) {
+          persister ! PersistMe(s"e-$i", probe.ref)
+          probe.expectMessage(10.seconds, Done)
+        }
+        val slice = sliceForPersistenceId(persistenceId, maxNumberOfSlices)
+        val result: TestSubscriber.Probe[EventEnvelope] =
+          doQuery(entityTypeHint, slice, slice, NoOffset)
+            .runWith(sinkProbe)
+            .request(21)
+        for (i <- 1 to 20) {
+          val expectedEvent = s"e-$i"
+          withClue(s"Expected event $expectedEvent") {
+            result.expectNextPF {
+              case EventEnvelope(_, _, _, `expectedEvent`) =>
+            }
+          }
+        }
+        assertFinished(result)
+      }
+
+      "only return events after an offset" in new Setup {
+        for (i <- 1 to 20) {
+          persister ! PersistMe(s"e-$i", probe.ref)
+          probe.expectMessage(Done)
+        }
+
+        val slice = sliceForPersistenceId(persistenceId, maxNumberOfSlices)
+        val result: TestSubscriber.Probe[EventEnvelope] =
+          doQuery(entityTypeHint, slice, slice, NoOffset)
+            .runWith(sinkProbe)
+            .request(21)
+
+        result.expectNextN(9)
+
+        val offset = result.expectNext().offset
+        result.cancel()
+
+        val withOffset =
+          doQuery(entityTypeHint, slice, slice, offset)
+            .runWith(TestSink.probe[EventEnvelope])
+        withOffset.request(12)
+        for (i <- 11 to 20) {
+          val expectedEvent = s"e-$i"
+          withClue(s"Expected event $expectedEvent") {
+            withOffset.expectNextPF {
+              case EventEnvelope(
+                  SpannerOffset(_, seen),
+                  persistenceId,
+                  sequenceNr,
+                  `expectedEvent`
+                  ) if seen(persistenceId) == sequenceNr =>
+            }
+          }
+        }
+        assertFinished(withOffset)
+      }
+
+      "retrieve from several slices" in new Setup {
+        val numberOfPersisters = 40
+        val numberOfEvents = 3
+        val persistenceIds = (1 to numberOfPersisters).map(_ => nextPid(entityTypeHint)).toVector
+        val persisters = persistenceIds.map { pid =>
+          println(s"# pid [$pid] in slice [${SliceUtils.sliceForPersistenceId(pid, maxNumberOfSlices)}]") // FIXME
+          val ref = testKit.spawn(TestActors.Persister(pid))
+          for (i <- 1 to numberOfEvents) {
+            ref ! PersistMe(s"e-$i", probe.ref)
+            probe.expectMessage(Done)
+          }
+        }
+
+        maxNumberOfSlices should be(128)
+        val ranges = SliceUtils.sliceRanges(4, maxNumberOfSlices)
+        ranges(0) should be(0 to 31)
+        ranges(1) should be(32 to 63)
+        ranges(2) should be(64 to 95)
+        ranges(3) should be(96 to 127)
+
+        val allEnvelopes =
+          (0 until 4).flatMap { rangeIndex =>
+            val result =
+              doQuery(entityTypeHint, ranges(rangeIndex).min, ranges(rangeIndex).max, NoOffset)
+                .runWith(Sink.seq)
+                .futureValue
+            println(
+              s"# result$rangeIndex (${result.size}): ${result
+                .map(env => s"${env.persistenceId} / ${env.sequenceNr} / ${env.event}")
+                .mkString(", ")}"
+            ) // FIXME
+            result.foreach { env =>
+              ranges(rangeIndex) should contain(SliceUtils.sliceForPersistenceId(env.persistenceId, maxNumberOfSlices))
+            }
+            result
+          }
+        allEnvelopes.size should be(numberOfPersisters * numberOfEvents)
+      }
+
+      // FIXME more tests... see EventsByTagSpec
+    }
+  }
+}

--- a/journal/src/test/scala/akka/persistence/spanner/PrintSchema.scala
+++ b/journal/src/test/scala/akka/persistence/spanner/PrintSchema.scala
@@ -31,6 +31,8 @@ object PrintSchema {
       pw.println("//#journal-tables")
       pw.println(SpannerJournalInteractions.Schema.Journal.journalTable(settings))
       pw.println("")
+      pw.println(SpannerJournalInteractions.Schema.Journal.sliceIndex(settings))
+      pw.println("")
       pw.println(SpannerJournalInteractions.Schema.Tags.tagTable(settings))
       pw.println("")
       pw.println(SpannerJournalInteractions.Schema.Tags.eventsByTagIndex(settings))

--- a/journal/src/test/scala/akka/persistence/spanner/SpannerSpec.scala
+++ b/journal/src/test/scala/akka/persistence/spanner/SpannerSpec.scala
@@ -145,9 +145,13 @@ trait SpannerLifecycle
 
   private val pidCounter = new AtomicLong(0)
   def nextPid() = s"p-${pidCounter.incrementAndGet()}"
+  def nextPid(entityTypeHint: String) = s"$entityTypeHint|p-${pidCounter.incrementAndGet()}"
 
   private val tagCounter = new AtomicLong(0)
   def nextTag = s"tag-${tagCounter.incrementAndGet()}"
+
+  private val entityTypeHintCounter = new AtomicLong(0)
+  def nextEntityTypeHint = s"TestEntity-${entityTypeHintCounter.incrementAndGet()}"
 
   val spannerSettings = new SpannerSettings(testKit.system.settings.config.getConfig("akka.persistence.spanner"))
   val grpcSettings: GrpcClientSettings = if (spannerSettings.useAuth) {
@@ -206,7 +210,9 @@ trait SpannerLifecycle
     log.debug("Used settings: {}", spannerSettings)
     log.info("Creating database {}", spannerSettings.database)
 
-    val dbSchemas: List[String] = SpannerJournalInteractions.Schema.Journal.journalTable(spannerSettings) ::
+    val dbSchemas: List[String] =
+      SpannerJournalInteractions.Schema.Journal.journalTable(spannerSettings) ::
+      SpannerJournalInteractions.Schema.Journal.sliceIndex(spannerSettings) ::
       SpannerJournalInteractions.Schema.Tags.tagTable(spannerSettings) ::
       SpannerJournalInteractions.Schema.Tags.eventsByTagIndex(spannerSettings) ::
       SpannerJournalInteractions.Schema.Deleted.deleteMetadataTable(spannerSettings) :: Nil ++

--- a/testkit/src/main/scala/akka/persistence/spanner/testkit/SpannerTestkit.scala
+++ b/testkit/src/main/scala/akka/persistence/spanner/testkit/SpannerTestkit.scala
@@ -98,6 +98,7 @@ final class SpannerTestkit(systemProvider: ClassicActorSystemProvider) {
             parent = spannerSettings.parent,
             s"CREATE DATABASE ${spannerSettings.database}",
             SpannerJournalInteractions.Schema.Journal.journalTable(spannerSettings) ::
+            SpannerJournalInteractions.Schema.Journal.sliceIndex(spannerSettings) ::
             SpannerJournalInteractions.Schema.Tags.tagTable(spannerSettings) ::
             SpannerJournalInteractions.Schema.Tags.eventsByTagIndex(spannerSettings) ::
             SpannerJournalInteractions.Schema.Deleted.deleteMetadataTable(spannerSettings) ::


### PR DESCRIPTION
I had a go at "dynamic slices" that we have talked so much about...

* to allow for more dynamic slicing of events in projections
* events are written with their slice id, 0 until 128 (hash modulo of persistenceId)
* events are queried with slice range
  * for example, if starting with 4 projection instances it would be ranges
    0 to 31, 32 to 63, 64 to 95, 96 to 128
  * when scaling out is needed the offset for these ranges can be copied
    and starting more projection instances with smaller ranges, such as
    0 to 15, 16 to 31, ...
